### PR TITLE
Fixed import statements in Java Example File

### DIFF
--- a/example/src/main/java/example/JavaOllieWrapper.java
+++ b/example/src/main/java/example/JavaOllieWrapper.java
@@ -3,11 +3,11 @@ package example;
 import java.io.File;
 import java.net.MalformedURLException;
 
-import edu.washington.cs.knowitall.ollie.Ollie;
-import edu.washington.cs.knowitall.ollie.OllieExtraction;
-import edu.washington.cs.knowitall.ollie.OllieExtractionInstance;
-import edu.washington.cs.knowitall.tool.parse.MaltParser;
-import edu.washington.cs.knowitall.tool.parse.graph.DependencyGraph;
+import edu.knowitall.ollie.Ollie;
+import edu.knowitall.ollie.OllieExtraction;
+import edu.knowitall.ollie.OllieExtractionInstance;
+import edu.knowitall.tool.parse.MaltParser;
+import edu.knowitall.tool.parse.graph.DependencyGraph;
 
 /** This is an example class that shows one way of using Ollie from Java. */
 public class JavaOllieWrapper {


### PR DESCRIPTION
A package was renamed awhile ago and 'edu.washington.cs.knowitall' became 'edu.knowitall'
